### PR TITLE
Dashboard user pref

### DIFF
--- a/create_databases/iqc_db/update_iqc_1.1.0_1.2.0.sql
+++ b/create_databases/iqc_db/update_iqc_1.1.0_1.2.0.sql
@@ -1,0 +1,7 @@
+
+-- kolom prefmodality toevoegen aan users tabel
+ALTER TABLE `users` ADD `prefmodality` VARCHAR(32) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL AFTER `email`;
+
+-- database versie
+UPDATE config SET value='1.2.0',date_modified='2017-01-30' WHERE property='Version_Database';
+

--- a/create_databases/update_iqc_1.0.0_1.1.0.sh
+++ b/create_databases/update_iqc_1.0.0_1.1.0.sh
@@ -9,8 +9,7 @@ echo
 
 mysql -uroot iqc -p$1 < iqc_db/update_iqc_1.0.0_1.1.0.sql
 
-echo.
+echo
 echo Done...
-echo.
+echo
 
-pause

--- a/create_databases/update_iqc_1.1.0_1.2.0.cmd
+++ b/create_databases/update_iqc_1.1.0_1.2.0.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+set MYSQL=c:\xampp\mysql\bin\mysql.exe
+rem set MYSQL=C:\wamp\bin\mysql\mysql5.5.20\bin\mysql.exe
+set ROOTPWD=
+
+echo.
+echo Kolom "prefmodality" toevoegen aan tabel users
+echo.
+
+%MYSQL% -uroot iqc -p%ROOTPWD% < iqc_db\update_iqc_1.1.0_1.2.0.sql
+
+echo.
+echo Done...
+echo.
+
+pause
+

--- a/create_databases/update_iqc_1.1.0_1.2.0.sh
+++ b/create_databases/update_iqc_1.1.0_1.2.0.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# optional first argument = mysql root password 
+
+echo
+echo - Kolom "prefmodality" toevoegen aan tabel users
+echo
+
+mysql -uroot iqc -p$1 < iqc_db/update_iqc_1.1.0_1.2.0.sql
+
+echo
+echo Done...
+echo
+

--- a/website/WAD-IQC/database/globals.php
+++ b/website/WAD-IQC/database/globals.php
@@ -87,7 +87,7 @@ $password_dcm4chee="wad";
 $databaseName_dcm4chee = "pacsdb";
 
 // Version of WAD_Interface
-$version = "1.1.0";
+$version = "1.2.0";
 
 
 

--- a/website/WAD-IQC/database/iqc/create_users.php
+++ b/website/WAD-IQC/database/iqc/create_users.php
@@ -64,6 +64,7 @@ $b=($j%2);
    $table_data->assign("initials",$field_users->initials);
    $table_data->assign("phone",$field_users->phone);
    $table_data->assign("email",$field_users->email);
+   $table_data->assign("prefmodality",$field_users->prefmodality);
    
    $table_data->assign("action",$action);
    if (!empty($user_level_1))

--- a/website/WAD-IQC/database/iqc/menu_structure.php
+++ b/website/WAD-IQC/database/iqc/menu_structure.php
@@ -68,7 +68,7 @@ $action['top']['Status']='../iqc/frontpage-bottom.html';
 
 
 $level['Results']['Selector']=1;
-$level['Results']['Dashboard']=1;
+$level['Results']['Dashboard']=2;
 
 $action['Results']['Selector']='../iqc/show_selector.php';
 $action['Results']['Dashboard']='../iqc/show_dashboard.php';

--- a/website/WAD-IQC/database/iqc/new_users.php
+++ b/website/WAD-IQC/database/iqc/new_users.php
@@ -60,6 +60,7 @@ if( (!empty($_POST['action']) ) )
   $users_initials=$_POST['users_initials'];
   $users_phone=$_POST['users_phone'];
   $users_email=$_POST['users_email'];
+  $users_preferred_modality=$_POST['users_preferred_modality'];
   
   //priveleges
   $message2=''; 
@@ -146,9 +147,9 @@ if( (!empty($_POST['action']) ) )
 		exit();
 	 }
 	 
-     $addStmt = "Insert into $table_users(firstname,lastname,initials,phone,email,login_level_1,login_level_2,login_level_3,login_level_4,login_level_5,login,password) values ('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s')";
+     $addStmt = "Insert into $table_users(firstname,lastname,initials,phone,email,prefmodality,login_level_1,login_level_2,login_level_3,login_level_4,login_level_5,login,password) values ('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s')";
 
-     $addStmt=sprintf($addStmt,$users_firstname,$users_lastname,$users_initials,$users_phone,$users_email,$login_level_1,$login_level_2,$login_level_3,$login_level_4,$login_level_5,$users_login,md5($first_login));
+     $addStmt=sprintf($addStmt,$users_firstname,$users_lastname,$users_initials,$users_phone,$users_email,$users_preferred_modality,$login_level_1,$login_level_2,$login_level_3,$login_level_4,$login_level_5,$users_login,md5($first_login));
    
      if (!($link->query($addStmt))) 
      {
@@ -168,8 +169,8 @@ if( (!empty($_POST['action']) ) )
     
     $table_users='users';
     
-    $updateStmt = "Update $table_users set  firstname='%s',lastname='%s',initials='%s',phone='%s',email='%s',login_level_1='%s',login_level_2='%s',login_level_3='%s',login_level_4='%s',login_level_5='%s',login='%s' where $table_users.pk='%d'";
-    $updateStmt=sprintf($updateStmt,$users_firstname,$users_lastname,$users_initials,$users_phone,$users_email,$login_level_1,$login_level_2,$login_level_3,$login_level_4,$login_level_5,$users_login,$users_pk);
+    $updateStmt = "Update $table_users set  firstname='%s',lastname='%s',initials='%s',phone='%s',email='%s',prefmodality='%s',login_level_1='%s',login_level_2='%s',login_level_3='%s',login_level_4='%s',login_level_5='%s',login='%s' where $table_users.pk='%d'";
+    $updateStmt=sprintf($updateStmt,$users_firstname,$users_lastname,$users_initials,$users_phone,$users_email,$users_preferred_modality,$login_level_1,$login_level_2,$login_level_3,$login_level_4,$login_level_5,$users_login,$users_pk);
     
     if (!($link->query($updateStmt))) 
     {
@@ -229,6 +230,7 @@ if( (!empty($_POST['action']) ) )
     $users->assign("default_users_lastname",$field_users->lastname);
     $users->assign("default_users_phone",$field_users->phone);
     $users->assign("default_users_email",$field_users->email);
+    $users->assign("default_users_preferred_modality",$field_users->prefmodality);
     $users->assign("default_users_initials",$field_users->initials);
     $users->assign("default_users_login",$field_users->login);
     $checked1='';

--- a/website/WAD-IQC/database/iqc/view_users.php
+++ b/website/WAD-IQC/database/iqc/view_users.php
@@ -44,6 +44,7 @@ if (!($result_users= $link->query($users_Stmt))) {
   $users->assign("default_users_lastname",$field_users->lastname);
   $users->assign("default_users_phone",$field_users->phone);
   $users->assign("default_users_email",$field_users->email);
+  $users->assign("default_users_preferred_modality",$field_users->prefmodality);
   $users->assign("default_users_initials",$field_users->initials);
   $users->assign("default_users_login",$field_users->login);
   $checked1='';

--- a/website/WAD-IQC/database/login/login_verify.php
+++ b/website/WAD-IQC/database/login/login_verify.php
@@ -80,13 +80,16 @@ if (md5($user_password)==$pw_field->password)
     // JK - by default choose results --> selector instead of nothing
     //$selected_top='100';
     //$selected_bottom='100';
+    // Select results - dashboard at login
     $selected_top='1';
-    $selected_bottom='1';
+    $selected_bottom='2';
+    $preferred_modality=$pw_field->prefmodality;
 
 
     // JK: change default behaviour: display results / selector table by default
     //$bottom_frame=sprintf("../iqc/frontpage-bottom.html");
-    $bottom_frame=sprintf("../iqc/show_selector.php");
+    //$bottom_frame=sprintf("../iqc/show_selector.php");
+    $bottom_frame=sprintf("../iqc/show_dashboard.php?modaliteit=$preferred_modality");
     $executestring.= sprintf("../main/main_iqc.php?top_menu=$top_menu&bottom_menu=$bottom_menu&selected_top=$selected_top&selected_bottom=$selected_bottom&bottom_frame=$bottom_frame&t=%d",time());
     header($executestring);
     exit();

--- a/website/WAD-Smarty_dir/templates/new_users.tpl
+++ b/website/WAD-Smarty_dir/templates/new_users.tpl
@@ -48,6 +48,12 @@
             <input   name="users_email" type="text" value="{$default_users_email}" size="30"> </input>
           </td>
         </tr>
+        <tr>
+          <td class="table_data_blue"> Preferred Modality </td>
+          <td class="table_data"> 
+            <input   name="users_preferred_modality" type="text" value="{$default_users_preferred_modality}" size="30"> </input>
+          </td>
+        </tr>
 
 
 

--- a/website/WAD-Smarty_dir/templates/users_select_header.tpl
+++ b/website/WAD-Smarty_dir/templates/users_select_header.tpl
@@ -7,4 +7,5 @@
       <td class="table_data_header_bold">Initialen&nbsp;&nbsp;</td>
       <td class="table_data_header_bold">Telefoon&nbsp;&nbsp;</td>
       <td class="table_data_header_bold">E-mail&nbsp;&nbsp;</td>
+      <td class="table_data_header_bold">Voorkeursmodaliteit&nbsp;&nbsp;</td>
 </tr>

--- a/website/WAD-Smarty_dir/templates/users_select_row.tpl
+++ b/website/WAD-Smarty_dir/templates/users_select_row.tpl
@@ -21,4 +21,7 @@
   <td class="table_data">
     {$email}
   </td>
+  <td class="table_data">
+    {$prefmodality}
+  </td>
 </tr>

--- a/website/WAD-Smarty_dir/templates/view_users.tpl
+++ b/website/WAD-Smarty_dir/templates/view_users.tpl
@@ -33,6 +33,10 @@
           <td class="table_data_blue"> Email </td>
           <td class="table_data"> {$default_users_email} </td>
         </tr>
+        <tr>
+          <td class="table_data_blue"> Preferred Modality </td>
+          <td class="table_data"> {$default_users_preferred_modality} </td>
+        </tr>
 </table>
 
 <hr>

--- a/website/WAD-Smarty_dir/templates/view_users_select.tpl
+++ b/website/WAD-Smarty_dir/templates/view_users_select.tpl
@@ -35,6 +35,10 @@
           <td class="table_data_blue"> Email </td>
           <td class="table_data"> {$default_users_email} </td>
         </tr>
+        <tr>
+          <td class="table_data_blue"> Preferred Modality </td>
+          <td class="table_data"> {$default_users_preferred_modality} </td>
+        </tr>
 </table>
 
 <hr>


### PR DESCRIPTION
Add "user preferred modality" to dashboard:
- show dashboard at login
- filter modality if configured for user (using existing grouping functionality)

NOTE: needs modification of users table in data base, run the update script in create_databases folder. New database version 1.2.0.

Concept: allow technicians who check their QC results to see a shorter list of modalities. This modification allows to create dedicated users working on specific modalities.
If you don't want it, leave the preferred modality field empty and the only change is that the dashboard will be shown after login, instead of the "results" table.